### PR TITLE
Updating contact.html

### DIFF
--- a/_includes/contact.html
+++ b/_includes/contact.html
@@ -37,6 +37,11 @@
                             </div>
                             {% endfor %}
                             <div class="col-xs-12">
+                                <div class="control-group form-group">
+                                    <textarea rows = "5" cols = "50" class="form-control" placeholder="Please enter your message." required="" id="message" name="message" maxlength="500" autocomplete="off"></textarea>
+							    </div>
+                            </div>
+                            <div class="col-xs-12">
                                 <div class="form-group">
                                     <div class="custom-checkbox">
                                         You can contact me (rarely) by email with additional information about this project (e.g., beta testing opportunities) or requests for feedback, additional questions, etc.) 


### PR DESCRIPTION
The contact us page misses a text area for message content. The message box exists in this modification and this is the link to the issue:
https://github.com/ModECI/MDF/issues/202